### PR TITLE
Añadir Nombre y Apellido al crear usuarios

### DIFF
--- a/Concesionaria.API/Controllers/UsuariosController.cs
+++ b/Concesionaria.API/Controllers/UsuariosController.cs
@@ -64,7 +64,13 @@ namespace Concesionaria.API.Controllers
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
-            var user = new ApplicationUser { UserName = dto.UserName, Email = dto.Email };
+            var user = new ApplicationUser { 
+                UserName = dto.UserName,
+                Email = dto.Email,
+                Nombre = dto.Nombre,
+                Apellido = dto.Apellido
+            };
+
             var result = await _userManager.CreateAsync(user, dto.Password);
             if (result.Succeeded)
                 return CreatedAtAction(nameof(GetUsuarios), new { id = user.Id }, user);


### PR DESCRIPTION
Se ha actualizado el método `CrearUsuario` en `UsuariosController.cs` para incluir los campos `Nombre` y `Apellido` al crear un nuevo usuario (`ApplicationUser`).

Anteriormente, solo se asignaban los valores de `UserName` y `Email`. Este cambio permite almacenar información adicional sobre los usuarios, mejorando la funcionalidad del sistema. #17